### PR TITLE
コードスタイルの修正

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-  tauri_build::build()
+    tauri_build::build()
 }

--- a/src-tauri/src/api.rs
+++ b/src-tauri/src/api.rs
@@ -19,20 +19,15 @@ pub async fn login(
         user_name, password, "localhost", port, db_name
     );
 
-    let pool_new = match db::get_new_pool::<MySql>(&database_url).await {
-        Some(pool_new) => pool_new,
-        None => {
-            return Err("connection failed.....".to_string());
-        }
-    };
+    let pool_new = db::get_new_pool::<MySql>(&database_url)
+        .await
+        .ok_or_else(|| "connection failed.....".to_string())?;
 
     {
-        let mut guard = match pool.0.lock() {
-            Ok(guard) => guard,
-            Err(e) => {
-                return Err(format!("{e}: connection failed....."));
-            }
-        };
+        let mut guard = pool
+            .0
+            .lock()
+            .map_err(|e| format!("{e}: connection failed....."))?;
         *guard = Some(pool_new);
     }
 
@@ -44,10 +39,7 @@ pub async fn show_mysql_tables(
     db_name: &str,
     pool: State<'_, MySqlPool>,
 ) -> Result<String, String> {
-    let pool = match get_mysql_pool(pool) {
-        Some(pool) => pool,
-        None => return Err("failed getting mysql pool".to_string()),
-    };
+    let pool = get_mysql_pool(pool).ok_or_else(|| "failed getting mysql pool".to_string())?;
 
     db::get_mysql_table_names(&pool, db_name).await
 }
@@ -58,10 +50,7 @@ pub async fn show_mysql_columns(
     table_name: &str,
     pool: State<'_, MySqlPool>,
 ) -> Result<String, String> {
-    let pool = match get_mysql_pool(pool) {
-        Some(pool) => pool,
-        None => return Err("failed getting mysql pool".to_string()),
-    };
+    let pool = get_mysql_pool(pool).ok_or_else(|| "failed getting mysql pool".to_string())?;
 
     db::get_mysql_column_names(&pool, db_name, table_name).await
 }
@@ -72,10 +61,7 @@ pub async fn show_mysql_table_details(
     table_name: &str,
     pool: State<'_, MySqlPool>,
 ) -> Result<String, String> {
-    let pool = match get_mysql_pool(pool) {
-        Some(pool) => pool,
-        None => return Err("failed getting mysql pool".to_string()),
-    };
+    let pool = get_mysql_pool(pool).ok_or_else(|| "failed getting mysql pool".to_string())?;
 
     db::get_mysql_table_details(&pool, db_name, table_name).await
 }
@@ -86,10 +72,7 @@ pub async fn show_mysql_column_details(
     table_name: &str,
     pool: State<'_, MySqlPool>,
 ) -> Result<String, String> {
-    let pool = match get_mysql_pool(pool) {
-        Some(pool) => pool,
-        None => return Err("failed getting mysql pool".to_string()),
-    };
+    let pool = get_mysql_pool(pool).ok_or_else(|| "failed getting mysql pool".to_string())?;
 
     db::get_mysql_column_details(&pool, db_name, table_name).await
 }
@@ -101,10 +84,7 @@ pub async fn show_mysql_table_data(
     column_names: Vec<&str>,
     pool: State<'_, MySqlPool>,
 ) -> Result<String, String> {
-    let pool = match get_mysql_pool(pool) {
-        Some(pool) => pool,
-        None => return Err("failed getting mysql pool".to_string()),
-    };
+    let pool = get_mysql_pool(pool).ok_or_else(|| "failed getting mysql pool".to_string())?;
 
     db::get_mysql_table_data(&pool, db_name, table_name, column_names).await
 }

--- a/src-tauri/src/api/db.rs
+++ b/src-tauri/src/api/db.rs
@@ -7,7 +7,7 @@ pub struct MySqlPool(pub Mutex<Option<Pool<MySql>>>);
 pub async fn get_new_pool<DB: Database>(db_url: &str) -> Option<Pool<DB>> {
     let pool_ret = pool::PoolOptions::<DB>::new()
         .max_connections(20)
-        .connect(&db_url)
+        .connect(db_url)
         .await;
 
     match pool_ret {
@@ -24,10 +24,7 @@ pub fn get_mysql_pool(pool: State<'_, MySqlPool>) -> Option<Pool<MySql>> {
         }
     };
 
-    match guard.as_ref() {
-        Some(pool) => Some(pool.clone()),
-        None => None,
-    }
+    guard.as_ref().cloned()
 }
 
 fn result_to_jsonstr<T: serde::Serialize>(data: &Vec<T>) -> String {
@@ -163,7 +160,7 @@ pub async fn get_mysql_table_data(
             "'\"{0}\": ', '\"', IFNULL(CAST(`{0}` AS CHAR(1000) CHARACTER SET utf8), 'undefined data'), '\"'",
             column_name
         );
-        add_name = if &concat_arg == "" {
+        add_name = if concat_arg.is_empty() {
             add_name
         } else {
             format!(", ',', {}", &add_name)

--- a/src-tauri/src/api/db.rs
+++ b/src-tauri/src/api/db.rs
@@ -5,41 +5,26 @@ use tauri::State;
 pub struct MySqlPool(pub Mutex<Option<Pool<MySql>>>);
 
 pub async fn get_new_pool<DB: Database>(db_url: &str) -> Option<Pool<DB>> {
-    let pool_ret = pool::PoolOptions::<DB>::new()
+    pool::PoolOptions::<DB>::new()
         .max_connections(20)
         .connect(db_url)
-        .await;
-
-    match pool_ret {
-        Ok(pool) => Some(pool),
-        Err(_e) => None,
-    }
+        .await
+        .ok()
 }
 
 pub fn get_mysql_pool(pool: State<'_, MySqlPool>) -> Option<Pool<MySql>> {
-    let guard = match pool.0.lock() {
-        Ok(guard) => guard,
-        Err(_e) => {
-            return None;
-        }
-    };
-
-    guard.as_ref().cloned()
+    pool.0.lock().ok()?.as_ref().cloned()
 }
 
 fn result_to_jsonstr<T: serde::Serialize>(data: &Vec<T>) -> String {
-    let ret = serde_json::to_string(data);
-    match ret {
-        Ok(json_str) => json_str,
-        Err(_e) => "failed converting json format string.....".to_string(),
-    }
+    serde_json::to_string(data)
+        .unwrap_or_else(|_| "failed converting json format string.....".to_string())
 }
 
 fn get_db_error_message(db_error: Option<&dyn DatabaseError>) -> String {
-    match db_error {
-        Some(msg) => msg.message().to_string(),
-        None => "error_message: empty".to_string(),
-    }
+    db_error
+        .map(|msg| msg.message().to_string())
+        .unwrap_or_else(|| "error_message: empty".to_string())
 }
 
 #[derive(sqlx::FromRow, Debug, serde::Serialize)]
@@ -55,10 +40,9 @@ pub async fn get_mysql_table_names(pool: &Pool<MySql>, db_name: &str) -> Result<
     .fetch_all(pool)
     .await;
 
-    match &table_names {
-        Ok(names) => Ok(result_to_jsonstr(names)),
-        Err(e) => Err(get_db_error_message(e.as_database_error())),
-    }
+    table_names
+        .map(|names| result_to_jsonstr(&names))
+        .map_err(|e| get_db_error_message(e.as_database_error()))
 }
 
 #[derive(sqlx::FromRow, Debug, serde::Serialize)]
@@ -79,10 +63,9 @@ pub async fn get_mysql_column_names(
     .fetch_all(pool)
     .await;
 
-    match &column_names {
-        Ok(names) => Ok(result_to_jsonstr(names)),
-        Err(e) => Err(get_db_error_message(e.as_database_error())),
-    }
+    column_names
+        .map(|names| result_to_jsonstr(&names))
+        .map_err(|e| get_db_error_message(e.as_database_error()))
 }
 
 #[derive(sqlx::FromRow, Debug, serde::Serialize)]
@@ -107,10 +90,9 @@ pub async fn get_mysql_table_details(
     .fetch_all(pool)
     .await;
 
-    match &table_details {
-        Ok(details) => Ok(result_to_jsonstr(details)),
-        Err(e) => Err(get_db_error_message(e.as_database_error())),
-    }
+    table_details
+        .map(|details| result_to_jsonstr(&details))
+        .map_err(|e| get_db_error_message(e.as_database_error()))
 }
 
 #[derive(sqlx::FromRow, Debug, serde::Serialize)]
@@ -137,10 +119,9 @@ pub async fn get_mysql_column_details(
     .fetch_all(pool)
     .await;
 
-    match &column_details {
-        Ok(details) => Ok(result_to_jsonstr(details)),
-        Err(e) => Err(get_db_error_message(e.as_database_error())),
-    }
+    column_details
+        .map(|details| result_to_jsonstr(&details))
+        .map_err(|e| get_db_error_message(e.as_database_error()))
 }
 
 #[derive(sqlx::FromRow, Debug, serde::Serialize)]
@@ -175,8 +156,7 @@ pub async fn get_mysql_table_data(
 
     println!("{:?}", &table_data_list);
 
-    match &table_data_list {
-        Ok(data_list) => Ok(result_to_jsonstr(data_list)),
-        Err(e) => Err(get_db_error_message(e.as_database_error())),
-    }
+    table_data_list
+        .map(|data_list| result_to_jsonstr(&data_list))
+        .map_err(|e| get_db_error_message(e.as_database_error()))
 }


### PR DESCRIPTION
- Clippy(Rustのリンター)の指示に従って修正を行いました。ClippyはRustに標準でバンドルされていて、`cargo clippy`で呼び出すことができます。
- 上に加えて、Option/Resultをパターンマッチで処理していた箇所をコンビネータで置き換えました。複雑さによってパターンマッチで処理した方がいい状況もありますが、基本的にはコンビネータで処理する方が好まれます。